### PR TITLE
fix "Source" link in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 [project.urls]
-Source = "https://github.com/ppatrzyk/filmweb"
+Source = "https://github.com/ppatrzyk/filmweb-export"
 
 [project.scripts]
 filmweb = "filmweb.main:main"


### PR DESCRIPTION
This fixes error 404 after clicking the "Source" button inside "Project links" section on PyPI.

Taka pierdoła, a prawie uniemożliwiła mi znalezienie repozytorium